### PR TITLE
Update discovery.md

### DIFF
--- a/docs/moderation/discovery.md
+++ b/docs/moderation/discovery.md
@@ -1,12 +1,12 @@
 # Discovery in a Decentralized System
 
-Finding new plugins and themes becomes more complex in a federated ecosystem. To facilitate discoverability, FAIR will maintain at least one Aggregator that functions as a directory of available Repository Nodes and their packages.
+Finding new plugins and themes becomes more complex in a federated ecosystem. To facilitate discoverability, FAIR will maintain at least one Aggregator that functions as a directory of available Repositories and their packages.
 
 ## Aggregator Participation
 
-Any Aggregator may choose to list Nodes and packages from the federation. Aggregators may:
+Any Aggregator may choose to list Repositories and packages from the federation. Aggregators may:
 
-- Set their own listing guidelines (unless conflicting with protocol standards).
+- Set their own listing guidelines which do not conflict with protocol standards.
 - Submit their own Aggregators to other Aggregators, forming a recursive discovery chain.
 
 This decentralized structure encourages diversity while maintaining compatibility through the FAIR Protocol.


### PR DESCRIPTION
change "node" to "repository" to match definitions at https://github.com/fairpm/fair-protocol/blob/main/specification.md

clarify aggregators guidelines not to conflict with FAIR protocol standards

Note - "node" is an ambiguous term; technically anything in the network is a node, but we often use the term when we mean "repository".